### PR TITLE
Support for arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ module.exports = function (target, app, cb) {
 
 	var cmd;
 	var args = [];
+    var app_args = [];
+    if (app instanceof Array) { app_args = app.splice(1); app = app[0] }
 
 	if (process.platform === 'darwin') {
 		cmd = 'open';
@@ -46,6 +48,7 @@ module.exports = function (target, app, cb) {
 		}
 	}
 
+    args = args.concat(app_args);
 	args.push(target);
 
 	// xdg-open will block the process unless stdio is ignored

--- a/test.js
+++ b/test.js
@@ -27,3 +27,11 @@ it('should open url in specified app', function (cb) {
 		cb();
 	});
 });
+
+it('should open url in specified app with arguments', function(cb) {
+	this.timeout(20000);
+	opn('http://sindresorhus.com', ['google-chrome', '--incognito'], function (err) {
+		assert(!err, err);
+		cb();
+    });
+})


### PR DESCRIPTION
I needed to pass a few flags to chrome. I have no means of testing outside Linux, so if it obviously breaks on other platforms, ignore it. :+1: 