### PR TITLE
Return the child process when calling `opn()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,4 +89,6 @@ module.exports = function (target, app, cb) {
 	} else {
 		cp.unref();
 	}
+
+	return cp;
 };

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,8 @@ Uses the command `open` on OS X, `start` on Windows and `xdg-open` on other plat
 
 ### opn(target, [app], [callback])
 
+Returns the [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You'd normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.
+
 #### target
 
 *Required*

--- a/test.js
+++ b/test.js
@@ -46,3 +46,8 @@ it('should open url in specified app with arguments', function (cb) {
 		cb();
 	});
 });
+
+it('should return the child process when called', function () {
+	var cp = opn('index.js');
+	assert('stdout' in cp);
+});


### PR DESCRIPTION
This in it self doesn't change any functionality, but will allow people to work directly with the child process how they see fit.

This PR might help with solving #2 