### PR TITLE
Replace app with options hash to allow disabling waiting for app close

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "file"
   ],
   "dependencies": {
-    "meow": "^3.3.0"
+    "meow": "^3.3.0",
+    "object-assign": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "*"

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ opn('http://sindresorhus.com', ['google chrome', '--incognito']);
 
 Uses the command `open` on OS X, `start` on Windows and `xdg-open` on other platforms.
 
-### opn(target, [app], [callback])
+### opn(target, [options], [callback])
 
 Returns the [spawned child process](https://nodejs.org/api/child_process.html#child_process_class_childprocess). You'd normally not need to use this for anything, but it can be useful if you'd like to attach custom event listeners or perform other operations directly on the spawned process.
 
@@ -56,7 +56,21 @@ The thing you want to open. Can be a URL, file, or executable.
 
 Opens in the default app for the file type. Eg. URLs opens in your default browser.
 
-#### app
+#### options
+
+Type: `object`
+
+An optional options hash.
+
+##### options.wait
+
+Type: `boolean`
+
+Defaults to `true` and means that opn will wait calling the callback (if one is given) until the app have been closed again. If set to `false` the callback will be called immediately after the child process have spawned.
+
+Note that waiting is only possible if the app name is either `darwin` or `win32`.
+
+##### options.app
 
 Type: `string`, `array`
 
@@ -68,7 +82,7 @@ The app name is platform dependent. Don't hard code it in reusable modules. Eg. 
 
 Type: `function`
 
-Called when the opened app exits.
+Called when the opened app exits or as soon as the child process have spawned if `options.wait` is set to `false`.
 
 On Windows you have to explicitly specify an app for it to be able to wait.
 

--- a/test.js
+++ b/test.js
@@ -21,6 +21,13 @@ it('should open file in default app', function () {
 	opn('index.js');
 });
 
+it('should not wait for the app to close if wait: false', function (cb) {
+	opn('http://sindresorhus.com', { wait: false }, function (err) {
+		assert.ifError(err);
+		cb();
+	});
+});
+
 it('should open url in default app', function (cb) {
 	this.timeout(20000);
 
@@ -32,7 +39,7 @@ it('should open url in default app', function (cb) {
 
 it('should open url in specified app', function (cb) {
 	this.timeout(20000);
-	opn('http://sindresorhus.com', 'firefox', function (err) {
+	opn('http://sindresorhus.com', { app: 'firefox' }, function (err) {
 		assert.ifError(err);
 		cb();
 	});
@@ -41,7 +48,7 @@ it('should open url in specified app', function (cb) {
 it('should open url in specified app with arguments', function (cb) {
 	this.timeout(20000);
 
-	opn('http://sindresorhus.com', [chromeName, '--incognito'], function (err) {
+	opn('http://sindresorhus.com', { app: [chromeName, '--incognito'] }, function (err) {
 		assert.ifError(err);
 		cb();
 	});


### PR DESCRIPTION
**WARNING: This is a breaking change!**

Fixes #2

It changes the api of the `opn` function from `opn(target, [app], [callback])` to `opn(target, [options], [callback])`. The use of a custom `app` is still allowed through the new `options.app` property.

It introduces a new `options.wait` boolean (default: `true`) which can be set to `false` if you do not wish the spawned process to keep your program hanging if `opn` is called with a `callback`. The `callback` will in that case be called immediately when the process have finished spawning.

This PR have only implemented `options.wait` for the platforms `darwin` and `win32`. Am I correct in assuming that waiting isn't supported on other platforms? 