### PR TITLE
Fixed a bug in opening file paths with spaces on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function (target, opts) {
 		}
 	} else if (process.platform === 'win32') {
 		cmd = 'cmd';
-		args.push('/c', 'start');
+		args.push('/c', 'start', '""');
 		target = target.replace(/&/g, '^&');
 
 		if (opts.wait) {


### PR DESCRIPTION
Previously attempting to opn a file path with spaces on windows would return ENOENT.

[Documentation here](http://ss64.com/nt/start.html) reveals that the first quoted parameter is assumed to be the title, if you look at [node-open](https://github.com/pwnall/node-open/blob/master/lib/open.js) you can see that in line 37 it gives the same explanation. In local testing including the "" parameter allowed for opening of folders with spaces.