### PR TITLE
allow for passing args directly to the 'open' command

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ module.exports = function (target, opts) {
 			args.push('-W');
 		}
 
+		if (opts.args) {
+			args.push(opts.args)
+		}
+
 		if (opts.app) {
 			args.push('-a', opts.app);
 		}


### PR DESCRIPTION
This enables passing args directly to the ‘open’ command.

For instance I want to issue this command:

```bash
open ../some-path/a-folder -R
```

I can now do:

```javascript
opn("../some-path/a-folder", {args: "-R"})
```

Currently there's no way to achieve this, as the only way to pass args is passing them directly to the application.