### PR TITLE
put --args [args] after the file argument on OS X

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,11 +31,6 @@ module.exports = function (target, opts) {
 		if (opts.app) {
 			args.push('-a', opts.app);
 		}
-
-		if (appArgs.length > 0) {
-			args.push('--args');
-			args = args.concat(appArgs);
-		}
 	} else if (process.platform === 'win32') {
 		cmd = 'cmd';
 		args.push('/c', 'start', '""');
@@ -71,6 +66,13 @@ module.exports = function (target, opts) {
 	}
 
 	args.push(target);
+
+	if (process.platform === 'darwin') {
+		if (appArgs.length > 0) {
+			args.push('--args');
+			args = args.concat(appArgs);
+		}
+	}
 
 	var cp = childProcess.spawn(cmd, args, cpOpts);
 


### PR DESCRIPTION
For the OSX open command, the --args [arg ...] arguments come after the file argument, not before:

````
NAME
     open -- open files and directories

SYNOPSIS
     open [-e] [-t] [-f] [-F] [-W] [-R] [-n] [-g] [-h] [-b bundle_identifier]
          [-a application] file ... [--args arg1 ...]
````

This shows itself as a bug in chrome in the case where chrome is running, but without any active windows.