### PR TITLE
1. Added possibility to open urls on win32 platforms with MS Edge

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,13 @@ module.exports = function (target, opts) {
 	}
 
 	args.push(target);
+	
+	// Edge browser can be opened: 'cmd /c "microsoft-edge:"'
+	// To open Edge with a url: 'cmd /c "microsoft-edge:http://www.google.de"
+	if (process.platform === 'win32' && (args[2].indexOf('edge') >= 0 || args[2].indexOf('Edge') >= 0)) {
+		console.log("Trying to launch edge browser ...");
+		args[2] = "microsoft-edge:" + args.pop();
+	}
 
 	if (process.platform === 'darwin' && appArgs.length > 0) {
 		args.push('--args');


### PR DESCRIPTION
On Win10 the Edge browser can be launched via:
`(cmd /c) start microsoft-edge:`

Or to launch a url directly:
`(cmd /c) start microsoft-edge:http://www.some.url`