### PR TITLE
Run process detached from its parent on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,11 +59,9 @@ module.exports = (target, opts) => {
 
 		if (!opts.wait) {
 			// `xdg-open` will block the process unless
-			// stdio is ignored even if it's unref'd
-			cpOpts.stdio = 'ignore';
-			// `xdg-open` will NOT stay running in the background 
-			// after the parent exits unless it is detached from 
-			// the parent AND it ignores the parent's stdio file descriptor 
+			// stdio is ignored and it's detached from the parent
+			// even if it's unref'd
+			cpOpts.stdio = 'ignore'; 
 			cpOpts.detached = true;
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ module.exports = (target, opts) => {
 			// `xdg-open` will block the process unless
 			// stdio is ignored even if it's unref'd
 			cpOpts.stdio = 'ignore';
+			// `xdg-open` will NOT stay running in the background 
+			// after the parent exits unless it is detached from 
+			// the parent AND it ignores the parent's stdio file descriptor 
+			cpOpts.detached = true;
 		}
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Type: `Object`
 Type: `boolean`<br>
 Default: `true`
 
-Wait for the opened app to exit before fulfilling the promise. If `false` it's fulfilled immediately when opening the app.
+Wait for the opened app to exit before fulfilling the promise. If `false` it's fulfilled immediately when opening the app, and the app is completely detached from the node process that spawned it.
 
 On Windows you have to explicitly specify an app for it to be able to wait.
 

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Type: `Object`
 Type: `boolean`<br>
 Default: `true`
 
-Wait for the opened app to exit before fulfilling the promise. If `false` it's fulfilled immediately when opening the app, and the app is completely detached from the node process that spawned it.
+Wait for the opened app to exit before fulfilling the promise. If `false` it's fulfilled immediately when opening the app.
 
 On Windows you have to explicitly specify an app for it to be able to wait.
 


### PR DESCRIPTION
Add option 'detached' to allow the opened app to continue running after the
parent process exits.

in Linux and MacOS if this option is true, the child process `stdio` is
set to 'ignore'.

______

The reason for this change is that I use `opn` to open a browser, but I don't want the browser to get closed when the node.js process exits, which is what currently happens, even if I set `wait` to false. The code is a bit messy because this option seems to conflic with `wait`. According to the [docs](https://nodejs.org/api/child_process.html#child_process_options_detached), to spawn a child process so that it can continue after parent exits 2 options are needed:
- set option `detached` true.
- set option `stdio` to 'ignore'.

it might be better add `stdio` option as well instead of just asuming that `detached` true implies the value of `stdio`.


