### PR TITLE
Only escape & in Windows when the string has no spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,10 @@ module.exports = (target, opts) => {
 	} else if (process.platform === 'win32') {
 		cmd = 'cmd';
 		args.push('/c', 'start', '""');
-		target = target.replace(/&/g, '^&');
+		
+		if(target.indexOf(" ") == -1){
+			target = target.replace(/&/g, '^&');
+		}
 
 		if (opts.wait) {
 			args.push('/wait');

--- a/test.js
+++ b/test.js
@@ -40,3 +40,7 @@ test('return the child process when called', async t => {
 	const cp = await m('index.js');
 	t.true('stdout' in cp);
 });
+
+test('open url with spaces and &', async () => {
+	await m('https://www.bing.com/images/search?&q=javascript logo&qft=+filterui:imagesize-large');
+});


### PR DESCRIPTION
After hitting the bug described in #44  , I played around a little with the spawn method and it seems like Windows' CMD only requires the ^ to escape &s if the string has no spaces, otherwise it will just interpret them as the literal ampersand and the ^ will be added to the string. (I assume that this is because strings with spaces are automatically escaped, to prevent the spaces from causing any trouble).

I added a condition to only escape the & in strings without spaces and it seems to solve those issues.
