### PR TITLE
Add support for Windows Subsystem for Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const childProcess = require('child_process');
+const os = require('os');
 
 module.exports = (target, opts) => {
 	if (typeof target !== 'string') {
@@ -13,6 +14,7 @@ module.exports = (target, opts) => {
 	let appArgs = [];
 	let args = [];
 	const cpOpts = {};
+	const isWSL = (os.type() === 'Linux' && os.release().indexOf('Microsoft') > -1);
 
 	if (Array.isArray(opts.app)) {
 		appArgs = opts.app.slice(1);
@@ -29,8 +31,8 @@ module.exports = (target, opts) => {
 		if (opts.app) {
 			args.push('-a', opts.app);
 		}
-	} else if (process.platform === 'win32') {
-		cmd = 'cmd';
+	} else if (process.platform === 'win32' || isWSL) {
+		cmd = 'cmd' + (isWSL ? '.exe' : '');
 		args.push('/c', 'start', '""');
 		target = target.replace(/&/g, '^&');
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const path = require('path');
 const childProcess = require('child_process');
-const os = require('os');
+const isWsl = require('is-wsl');
 
 module.exports = (target, opts) => {
 	if (typeof target !== 'string') {
@@ -14,7 +14,6 @@ module.exports = (target, opts) => {
 	let appArgs = [];
 	let args = [];
 	const cpOpts = {};
-	const isWSL = (os.type() === 'Linux' && os.release().indexOf('Microsoft') > -1);
 
 	if (Array.isArray(opts.app)) {
 		appArgs = opts.app.slice(1);
@@ -31,8 +30,8 @@ module.exports = (target, opts) => {
 		if (opts.app) {
 			args.push('-a', opts.app);
 		}
-	} else if (process.platform === 'win32' || isWSL) {
-		cmd = 'cmd' + (isWSL ? '.exe' : '');
+	} else if (process.platform === 'win32' || isWsl) {
+		cmd = 'cmd' + (isWsl ? '.exe' : '');
 		args.push('/c', 'start', '""');
 		target = target.replace(/&/g, '^&');
 

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
   },
   "xo": {
     "esnext": true
+  },
+  "dependencies": {
+    "is-wsl": "^1.1.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,15 +1,14 @@
-import os from 'os';
 import test from 'ava';
+import isWsl from 'is-wsl';
 import m from './';
 
-const isWSL = (os.type() === 'Linux' && os.release().indexOf('Microsoft') > -1);
 let chromeName;
 let firefoxName;
 
 if (process.platform === 'darwin') {
 	chromeName = 'google chrome canary';
 	firefoxName = 'firefox';
-} else if (process.platform === 'win32' || isWSL) {
+} else if (process.platform === 'win32' || isWsl) {
 	chromeName = 'Chrome';
 	firefoxName = 'C:\\Program Files\\Mozilla Firefox\\firefox.exe';
 } else if (process.platform === 'linux') {

--- a/test.js
+++ b/test.js
@@ -1,17 +1,23 @@
+import os from 'os';
 import test from 'ava';
 import m from './';
 
+const isWSL = (os.type() === 'Linux' && os.release().indexOf('Microsoft') > -1);
 let chromeName;
+let firefoxName;
 
 if (process.platform === 'darwin') {
 	chromeName = 'google chrome canary';
+	firefoxName = 'firefox';
+} else if (process.platform === 'win32' || isWSL) {
+	chromeName = 'Chrome';
+	firefoxName = 'C:\\Program Files\\Mozilla Firefox\\firefox.exe';
 } else if (process.platform === 'linux') {
 	chromeName = 'google-chrome';
-} else if (process.platform === 'win32') {
-	chromeName = 'Chrome';
+	firefoxName = 'firefox';
 }
 
-// tests only checks that opening doesn't return an error
+// Tests only checks that opening doesn't return an error
 // it has no way make sure that it actually opened anything
 
 // these have to be manually verified
@@ -29,7 +35,7 @@ test('open url in default app', async () => {
 });
 
 test('open url in specified app', async () => {
-	await m('http://sindresorhus.com', {app: 'firefox'});
+	await m('http://sindresorhus.com', {app: firefoxName});
 });
 
 test('open url in specified app with arguments', async () => {


### PR DESCRIPTION
With the Windows 10 Creators Update, the Windows Subsystem for Linux now allows for Windows commands to be called from the Linux environment (https://blogs.msdn.microsoft.com/commandline/2017/04/11/windows-10-creators-update-whats-new-in-bashwsl-windows-console/). 

This PR adds support for WSL by using the Windows logic and calling `cmd.exe` while in WSL, instead of `xdg-open`, which doesn't work. Cheers! 👋 