### PR TITLE
add console runner

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+var opn = require('./')
+
+var help = false
+
+var args = process.argv.slice(2).filter(function(arg) {
+  if (arg.match(/^(-+|\/)(h(elp)?|\?)$/))
+    help = true
+  else
+    return !!arg
+})
+
+if (help || args.length === 0) {
+  // If they didn't ask for help, then this is not a "success"
+  var log = help ? console.log : console.error
+  log('Usage: opn <path>]')
+  process.exit(help ? 0 : 1)
+} else {
+  opn(args[0])
+    .then(d => console.log("child process: " + d.pid))
+    .catch(err => console.error("cannot open: " + args[0]))
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "xo && ava"
   },
   "files": [
+    "bin.js",
     "index.js",
     "xdg-open"
   ],
@@ -46,6 +47,9 @@
     "website",
     "file"
   ],
+  "bin": {
+    "opn": "./bin.js"
+  },
   "dependencies": {
     "is-wsl": "^1.1.0"
   },


### PR DESCRIPTION
Added the ability to run `.opn()` from the command line (no options supported)

- it can be used by `package.json` scripts
```js
  .  .  .
  "scripts": {
    .  .  .
    "test:coverage": "... && nyc report --reporter=html && opn coverage/index.html"
  },
  .  .  .
```
Personally for me it is very useful. It opens coverage report with default browser on Linux/Windows/OSX.