### PR TITLE
fix: execute xdg-open in directory of opn

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = (target, opts) => {
 		if (opts.app) {
 			cmd = opts.app;
 		} else {
-			cmd = path.join(__dirname, 'xdg-open');
+			cmd = path.join('.', 'xdg-open');
 		}
 
 		if (appArgs.length > 0) {


### PR DESCRIPTION
If `/myApp/index.js` imports opn, it should be running `/myApp/node_modules/opn/xdg-open` but is instead looking for `/myApp/xdg-open`

`__dirname` will be the directory of the calling script, not necessarily the directory of opn. This PR looks for xdg-open in `.` instead.

This resolves issues with Linux users getting an ENOENT error as someone mentioned in https://github.com/sindresorhus/opn/issues/56. 

Tested on Ubuntu 17.10 in an Electron + Typescript app.