### PR TITLE
Use built-in xdg-open on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = (target, opts) => {
 		if (opts.app) {
 			cmd = opts.app;
 		} else {
-			cmd = path.join(__dirname, 'xdg-open');
+			cmd = process.platform === 'android' ? 'xdg-open' : path.join(__dirname, 'xdg-open');
 		}
 
 		if (appArgs.length > 0) {


### PR DESCRIPTION
When using `opn` inside of Termux on Android devices (and Chrome OS), the local version of `xdg-open` fails because of architecture issues. In these situations `xdg-open` is available system-wide. This PR updates the `cmd` to use the system-wide `xdg-open` on `android` devices.