### PR TITLE
feat(linux): use system xdg-open when available

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const childProcess = require('child_process');
+const commandExists = require('command-exists')
 const isWsl = require('is-wsl');
 
 module.exports = (target, opts) => {
@@ -49,8 +50,11 @@ module.exports = (target, opts) => {
 	} else {
 		if (opts.app) {
 			cmd = opts.app;
+		} else if (process.platform === 'android') {
+			cmd = 'xdg-open'
 		} else {
-			cmd = process.platform === 'android' ? 'xdg-open' : path.join(__dirname, 'xdg-open');
+			const xdgOpenInstalled = commandExists.sync('xdg-open')
+			cmd = xdgOpenInstalled ? 'xdg-open' : path.join(__dirname, 'xdg-open')
 		}
 
 		if (appArgs.length > 0) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"file"
 	],
 	"dependencies": {
+		"command-exists": "^1.2.7",
 		"is-wsl": "^1.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
`xdg-open` is already available in many desktop linux distributions. This PR changes the code to detect if it is available on the system and uses that one if detected.

This will fix:
* supplied/bundled xdg-open not compatible with your Linux distribution (Did not encouter this yet but could be a potential issue)
* when bundling your app with tools like https://github.com/zeit/pkg, it is not possible to include the `xdg-open` from this repo in the executable. You need to put the `xdg-open` file in the same directory as your project/app executable, which I'd like to avoid. Should fix #61 for most of the users. (Related: https://github.com/zeit/pkg/issues/213)

I am aware that users on linux without `xdg-open` installed will still have issues, when this lib is bundled via pkg, but I think this risk is acceptable. Especially because when supplying the app via a package manager like apt, a dependency to `xdg-utils` should do the trick.

What do you think @sindresorhus ?

:)