### PR TITLE
Fix Google Chrome app name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ opn('http://sindresorhus.com');
 opn('http://sindresorhus.com', {app: 'firefox'});
 
 // Specify app arguments
-opn('http://sindresorhus.com', {app: ['google chrome', '--incognito']});
+opn('http://sindresorhus.com', {app: ['chrome', '--incognito']});
 ```
 
 


### PR DESCRIPTION
The current "google chrome" results in an error of windows not being able to find the executable, however "chrome" works. I also tested it with incognito, which also works.